### PR TITLE
fix: do not send the common state after a custom one in setTaskStates

### DIFF
--- a/lib/orogen/templates/tasks/TaskBase.hpp
+++ b/lib/orogen/templates/tasks/TaskBase.hpp
@@ -108,9 +108,11 @@ namespace <%= space %>{
 
         bool start();
 
-        <% if task.extended_state_support? && !task.superclass.extended_state_support? %>
+        <% if task.extended_state_support? %>
 #ifdef RTT_HAS_STATE_CHANGE_HOOK
         void setTaskState(TaskState state);
+
+        <% unless task.superclass.extended_state_support? %>
 #else
         // Reimplement TaskCore base methods to export the states to the outside
         // world
@@ -118,6 +120,7 @@ namespace <%= space %>{
         bool recover();
         bool stop();
         bool cleanup();
+        <% end %>
 #endif
         <% end %>
 


### PR DESCRIPTION
This is actually a re-opening of https://github.com/orocos-toolchain/orogen/pull/147

It reestablishes the pre-setTaskState behavior, that is to not
send e.g. EXCEPTION after a custom exception in the exception/
runtime error/fatal error cases.

Since we were doing it purely from within TaskContext::exception() before,
only the "real" state was sent. Now, setTaskStates gets called *after*
the state change and this was getting published.

This actually broke state() for custom states, since state() returns
the last state that has been published.