### PR TITLE
feat: export IOR through pipe

### DIFF
--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -456,9 +456,9 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
     <% end %>
         message_ostream << "}";
         std::string message = message_ostream.str();
-        while (write_result < message.length() + 1) {
+        while (write_result < message.length()) {
             message.erase(0, write_result);
-            write_result = write(ior_write, message.c_str(), message.length() + 1);
+            write_result = write(ior_write, message.c_str(), message.length());
 
             if (write_result < 0) {
                 std::cerr << "failed to write on ior pipe" << std::endl;

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -175,7 +175,7 @@ int ORO_main(int argc, char* argv[])
 <% end %>
         ("with-ros", po::value<bool>()->default_value(false), "also publish the task as ROS node, default is false")
         ("rename", po::value< std::vector<std::string> >(), "rename a task of the deployment: --rename oldname:newname")
-        ("ior-write", po::value<int>(), "the write side of the ior pipe");
+        ("ior-write-fd", po::value<int>(), "the write file descriptor of the ior pipe");
 
    po::variables_map vm;
    po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -440,25 +440,19 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
 
     exiting = false;
 
-    if (vm.count("ior-write")) {
-        int ior_write = vm["ior-write"].as<int>();
-        std::string ior, message;
+    if (vm.count("ior-write-fd")) {
+        int ior_write = vm["ior-write-fd"].as<int>();
+        std::string ior;
         std::ostringstream message_ostream;
         int write_result;
 
     <% activity_ordered_tasks.each do |task| %>
         ior = RTT::corba::TaskContextServer::getIOR(task_<%= task.name %>.get());
         message_ostream << task_<%= task.name %>.get()->getName() << " " << ior << std::endl;
-        message = message_ostream.str();
-
-        write_result = write(ior_write, &message, sizeof(message));
-        if (write_result < 0) {
-            std::cerr << "failed writing on ior pipe" << std::endl;
-        }
-
     <% end %>
-        std::string ior_done = "DONE\n";
-        write_result = write(ior_write, &ior_done, sizeof(ior_done));
+        message_ostream << "DONE\n";
+        std::string message = message_ostream.str();
+        write_result = write(ior_write, message.c_str(), message.length() + 1);
         if (write_result < 0) {
             std::cerr << "failed writing on ior pipe" << std::endl;
         }

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -461,7 +461,7 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
             write_result = write(ior_write, message.c_str(), message.length());
 
             if (write_result < 0) {
-                std::cerr << "failed to write on ior pipe" << std::endl;
+                std::cerr << "failed to write on ior pipe (fd " << ior_write << "): " <<  strerror(errno)  << std::endl;
                 break;
             }
         }

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -440,8 +440,8 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
 
     exiting = false;
 
-    if (vm.count("ior_write")) {
-        int ior_write = vm["ior_write"].as<int>();
+    if (vm.count("ior-write")) {
+        int ior_write = vm["ior-write"].as<int>();
         std::string ior, message;
         std::ostringstream message_ostream;
         int write_result;

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -446,11 +446,15 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
         std::ostringstream message_ostream;
         int write_result = 0;
 
+        message_ostream << "{";
     <% activity_ordered_tasks.each do |task| %>
         ior = RTT::corba::TaskContextServer::getIOR(task_<%= task.name %>.get());
-        message_ostream << task_<%= task.name %>.get()->getName() << " " << ior << std::endl;
+        message_ostream << "\"" << task_<%= task.name %>.get()->getName() << "\": \"" << ior << "\"";
+    <% if task != activity_ordered_tasks.last %>
+        message_ostream << ",";
     <% end %>
-        message_ostream << "DONE\n";
+    <% end %>
+        message_ostream << "}";
         std::string message = message_ostream.str();
         while (write_result < message.length() + 1) {
             message.erase(0, write_result);


### PR DESCRIPTION
This makes it possible to get the tasks IOR without using CORBA name service or messing with simultaneous file accesses.

The task would get the pipe write side from an external argument, and publish sequential messages in the format of "task_name ior". Before closing the pipe, a "DONE" message is emitted, signaling the end of transmission to the pipe reader.