### PR TITLE
fix: move name constraints only for code generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ Rake::TestTask.new(:test) do |t|
     t.warning = false
 
     t.test_files = FileList.new("test/**/test_*.rb") do |fl|
-        fl.exclude { |p| %r{^test/gen}.match?(p) && (p != "test/gen/test_base.rb") }
+        fl.exclude { |p| %r{^test/gen}.match?(p) }
     end
 end
 

--- a/lib/orogen/base.rb
+++ b/lib/orogen/base.rb
@@ -14,7 +14,7 @@ require "find"
 class Module
     def enumerate_inherited_set(each_name, attribute_name = each_name) # :nodoc:
         class_eval <<-EOD, __FILE__, __LINE__
-        def find_#{attribute_name}(name) 
+        def find_#{attribute_name}(name)
             each_#{each_name} do |n|
                 return n if n.name == name
             end
@@ -94,7 +94,9 @@ module OroGen
         name = name.to_s if name.respond_to?(:to_sym)
         name = name.to_str
         if name !~ /^[a-zA-Z0-9_:][a-zA-Z0-9_:]*$/
-            raise ArgumentError, "task name '#{name}' invalid: it can contain only alphanumeric characters and '_', and cannot start with a number"
+            raise ArgumentError,
+                  "task name '#{name}' invalid: it can contain only alphanumeric "\
+                  "characters and '_', and cannot start with a number"
         end
 
         name

--- a/lib/orogen/gen/base.rb
+++ b/lib/orogen/gen/base.rb
@@ -19,6 +19,19 @@ module OroGen
                 generated_files << path
             end
 
+            def self.verify_valid_identifier(name, category)
+                name = name.to_s if name.respond_to?(:to_sym)
+                name = name.to_str
+                if name !~ /^[a-zA-Z0-9_:][a-zA-Z0-9_:]*$/
+                    raise ArgumentError,
+                          "#{category} name '#{name}' invalid: it may contain only "\
+                          "alphanumeric characters and '_', and cannot start "\
+                          "with a number"
+                end
+
+                name
+            end
+
             # Returns the C++ code which changes the current namespace from +old+
             # to +new+. +indent_size+ is the count of indent spaces between
             # namespaces.

--- a/lib/orogen/gen/base.rb
+++ b/lib/orogen/gen/base.rb
@@ -100,11 +100,10 @@ module OroGen
             end
 
             def self.each_pkgconfig_link_dependency(context, depspec)
-                return enum_for(:each_pkgconfig_link_dependency, context, depspec) unless block_given?
+                return enum_for(__method__, context, depspec) unless block_given?
+
                 depspec.each do |s|
-                    if s.in_context?(context, "link")
-                        yield "${#{s.var_name}_LIBRARIES}"
-                    end
+                    yield "${#{s.var_name}_LIBRARIES}" if s.in_context?(context, "link")
                 end
             end
 

--- a/lib/orogen/gen/enable.rb
+++ b/lib/orogen/gen/enable.rb
@@ -15,3 +15,4 @@ module OroGen
         end
     end
 end
+

--- a/lib/orogen/gen/enable.rb
+++ b/lib/orogen/gen/enable.rb
@@ -15,4 +15,3 @@ module OroGen
         end
     end
 end
-

--- a/lib/orogen/gen/tasks.rb
+++ b/lib/orogen/gen/tasks.rb
@@ -306,6 +306,43 @@ EOF
             # <tt>_time</tt> to be added to the generated class (more specifically,
             # to the +Base+ subclass).
             module TaskContextGeneration
+                def output_port(name, type, *args, **options)
+                    RTT_CPP.verify_valid_identifier(name, "output port")
+                    type = validate_interface_type(type)
+
+                    if type.name == "/std/vector<double>"
+                        Spec.warn(
+                            "#{type.name} is used as the port type for #{name}, "\
+                            "logging it will not be possible"
+                        )
+                    end
+                    super(name, type, *args, **options)
+                end
+
+                def input_port(name, type, *args, **options)
+                    RTT_CPP.verify_valid_identifier(name, "input port")
+                    type = validate_interface_type(type)
+                    super(name, type, *args, **options)
+                end
+
+                def property(name, type, *args, **options)
+                    RTT_CPP.verify_valid_identifier(name, "property")
+                    type = validate_interface_type(type)
+                    super(name, type, *args, **options)
+                end
+
+                def attribute(name, type, *args, **options)
+                    RTT_CPP.verify_valid_identifier(name, "attribute")
+                    type = validate_interface_type(type)
+                    super(name, type, *args, **options)
+                end
+
+                def validate_interface_type(type)
+                    type = project.find_interface_type(type)
+                    OroGen.validate_toplevel_type(type)
+                    type
+                end
+
                 # This method generates the relative basepath for generation of all files
                 def basepath
                     s = File.join(namespace.split("::").join(File::SEPARATOR))
@@ -349,7 +386,9 @@ EOF
                     name
                 end
 
-                def initialize(*, **)
+                def initialize(project, name = nil, **)
+                    RTT_CPP.verify_valid_identifier(name, "task") if name
+
                     super
 
                     hooks = %w{configure start update error exception fatal stop cleanup}

--- a/lib/orogen/gen/tasks.rb
+++ b/lib/orogen/gen/tasks.rb
@@ -306,7 +306,7 @@ EOF
             # <tt>_time</tt> to be added to the generated class (more specifically,
             # to the +Base+ subclass).
             module TaskContextGeneration
-                def output_port(name, type, *args, **options)
+                def output_port(name, type, **options)
                     RTT_CPP.verify_valid_identifier(name, "output port")
                     type = validate_interface_type(type)
 
@@ -316,25 +316,25 @@ EOF
                             "logging it will not be possible"
                         )
                     end
-                    super(name, type, *args, **options)
+                    super(name, type, **options)
                 end
 
-                def input_port(name, type, *args, **options)
+                def input_port(name, type, **options)
                     RTT_CPP.verify_valid_identifier(name, "input port")
                     type = validate_interface_type(type)
-                    super(name, type, *args, **options)
+                    super(name, type, **options)
                 end
 
-                def property(name, type, *args, **options)
+                def property(name, type, default_value = nil)
                     RTT_CPP.verify_valid_identifier(name, "property")
                     type = validate_interface_type(type)
-                    super(name, type, *args, **options)
+                    super(name, type, default_value)
                 end
 
-                def attribute(name, type, *args, **options)
+                def attribute(name, type, default_value = nil)
                     RTT_CPP.verify_valid_identifier(name, "attribute")
                     type = validate_interface_type(type)
-                    super(name, type, *args, **options)
+                    super(name, type, default_value)
                 end
 
                 def validate_interface_type(type)

--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -351,7 +351,7 @@ module OroGen
             # @return [Model<Typelib::Type>] the corresponding type in
             #   {#registry}
             # @raise Typelib::NotFound if the type cannot be found
-            def resolve_type(type, options = {})
+            def resolve_type(type, define_dummy_type: false)
                 typename =
                     if type.respond_to?(:name)
                         type.name
@@ -359,7 +359,7 @@ module OroGen
                     end
                 registry.get(typename)
             rescue Typelib::NotFound => e
-                unless define_dummy_types? || options[:define_dummy_type]
+                unless define_dummy_types? || define_dummy_type
                     raise e, "#{e.message} using #{self}", e.backtrace
                 end
 

--- a/lib/orogen/loaders/pkg_config.rb
+++ b/lib/orogen/loaders/pkg_config.rb
@@ -35,7 +35,7 @@ module OroGen
             Type = Struct.new :name, :exported
 
             def to_s
-                "#<OroGen::Loaders::PkgConfig(#{object_id.to_s(16)}) #{orocos_target}>"
+                "#<#{self.class}(#{object_id.to_s(16)}) #{orocos_target}>"
             end
 
             # @return [String] the name of the orocos target we are looking for

--- a/lib/orogen/spec/configuration_object.rb
+++ b/lib/orogen/spec/configuration_object.rb
@@ -43,16 +43,12 @@ module OroGen
 
             # Create a new property with the given name, type and default value
             def initialize(task, name, type, default_value)
-                name = name.to_s
-                if name !~ /^\w+$/
-                    raise ArgumentError, "property names need to be valid C++ identifiers, i.e. contain only alphanumeric characters and _ (got #{name})"
-                end
-
                 type = task.project.find_interface_type(type)
                 OroGen.validate_toplevel_type(type)
+
                 @dynamic = false
                 @task = task
-                @name = name
+                @name = name.to_s
                 @type = type
                 @default_value = default_value
                 @setter_operation = nil

--- a/lib/orogen/spec/operation.rb
+++ b/lib/orogen/spec/operation.rb
@@ -131,7 +131,9 @@ module OroGen
             # error
             def argument(name, qualified_type, doc = "")
                 if arguments.size >= RTT_ARGUMENT_COUNT_LIMIT
-                    raise ArgumentError, "RTT does not support having more than #{RTT_ARGUMENT_COUNT_LIMIT} arguments for an operation"
+                    raise ArgumentError,
+                          "RTT does not support having more than "\
+                          "#{RTT_ARGUMENT_COUNT_LIMIT} arguments for an operation"
                 end
 
                 type, qualified_type = find_interface_type(qualified_type)

--- a/lib/orogen/spec/operation.rb
+++ b/lib/orogen/spec/operation.rb
@@ -47,13 +47,8 @@ module OroGen
             RTT_ARGUMENT_COUNT_LIMIT = 4
 
             def initialize(task, name)
-                name = name.to_s
-                if name !~ /^\w+$/
-                    raise ArgumentError, "#{self.class.name.downcase} names need to be valid C++ identifiers, i.e. contain only alphanumeric characters and _ (got #{name})"
-                end
-
                 @task = task
-                @name = name
+                @name = name.to_s
                 @return_type = [nil, "void", ""]
                 @arguments = []
                 @in_caller_thread = false

--- a/lib/orogen/spec/port.rb
+++ b/lib/orogen/spec/port.rb
@@ -98,13 +98,8 @@ module OroGen
                 false
             end
 
-            def initialize(task, name, type, options = Hash.new)
-                if !name.kind_of?(Regexp)
-                    name = name.to_s
-                    if name !~ /^\w+$/
-                        raise ArgumentError, "port names need to be valid C++ identifiers, i.e. contain only alphanumeric characters and _ (got #{name})"
-                    end
-                elsif !type && !dynamic?
+            def initialize(task, name, type)
+                if !type && !dynamic?
                     raise ArgumentError, "only dynamic ports are allowed to have no type"
                 end
 
@@ -118,6 +113,9 @@ module OroGen
                         )
                     end
                 end
+
+                name = name.to_s unless name.kind_of?(Regexp)
+
                 @task = task
                 @name = name
                 @type = type

--- a/lib/orogen/spec/port.rb
+++ b/lib/orogen/spec/port.rb
@@ -112,7 +112,10 @@ module OroGen
                     type = task.project.find_interface_type(type)
                     OroGen.validate_toplevel_type(type)
                     if type.name == "/std/vector<double>"
-                        Spec.warn "#{type.name} is used as the port type for #{name}, logging it will not be possible"
+                        Spec.warn(
+                            "#{type.name} is used as the port type for #{name}, "\
+                            "logging it will not be possible"
+                        )
                     end
                 end
                 @task = task

--- a/lib/orogen/spec/project.rb
+++ b/lib/orogen/spec/project.rb
@@ -167,14 +167,6 @@ module OroGen
                     return
                 end
 
-                if name == self.name
-                    raise ArgumentError, "a task cannot have the same name as the project"
-                elsif name !~ /^(\w+::)*\w+$/
-                    raise ArgumentError, "task names need to be valid C++ identifiers, i.e. contain only alphanumeric characters and _ (got #{name})"
-                end
-
-                name = OroGen.verify_valid_identifier(name)
-
                 task = external_task_context(name, subclasses: subclasses, **options, &block)
                 task.extended_state_support
                 self_tasks[task.name] = task

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -1117,7 +1117,8 @@ module OroGen
                 check_uniqueness(name)
                 type = project.resolve_type(type)
 
-                @output_ports[name] = port = options[:class].new(self, name, type)
+                port = options[:class].new(self, name, type)
+                @output_ports[name] = port
                 Spec.load_documentation(port, /output_port/)
                 port
             end
@@ -1134,7 +1135,8 @@ module OroGen
                 check_uniqueness(name)
                 type = project.resolve_type(type)
 
-                @input_ports[name] = port = options[:class].new(self, name, type)
+                port = options[:class].new(self, name, type)
+                @input_ports[name] = port
                 Spec.load_documentation(port, /input_port/)
                 port
             end

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -613,7 +613,7 @@ module OroGen
             end
 
             def configuration_object(klass, name, type, default_value)
-                type = resolve_type_if_needed(type)
+                type = project.resolve_type(type)
 
                 if default_value
                     accepted = [Numeric, Symbol, String, TrueClass, FalseClass]
@@ -630,13 +630,6 @@ module OroGen
                 end
 
                 klass.new(self, name, type, default_value)
-            end
-
-            # @api private
-            #
-            # Resolve a type name into a type object, and leave type object alone
-            def resolve_type_if_needed(type)
-                project.resolve_type(type)
             end
 
             # Create a new property with the given name, type and default value
@@ -1122,7 +1115,7 @@ module OroGen
             def output_port(name, type, **options)
                 options = validate_options(options, class: OutputPort)
                 check_uniqueness(name)
-                type = resolve_type_if_needed(type) if type
+                type = project.resolve_type(type)
 
                 @output_ports[name] = port = options[:class].new(self, name, type)
                 Spec.load_documentation(port, /output_port/)
@@ -1139,7 +1132,7 @@ module OroGen
             def input_port(name, type, **options)
                 options = Kernel.validate_options(options, class: InputPort)
                 check_uniqueness(name)
-                type = resolve_type_if_needed(type) if type
+                type = project.resolve_type(type)
 
                 @input_ports[name] = port = options[:class].new(self, name, type)
                 Spec.load_documentation(port, /input_port/)
@@ -1275,7 +1268,7 @@ module OroGen
             # at runtime, with the type. This is not used by orogen himself, but
             # can be used by potential users of the orogen specification.
             def dynamic_input_port(name, type)
-                type = resolve_type_if_needed(type) if type
+                type = project.resolve_type(type) if type
                 dynamic_ports << DynamicInputPort.new(self, name, type)
                 dynamic_ports.last
             end
@@ -1287,7 +1280,7 @@ module OroGen
             # at runtime, with the type. This is not used by orogen himself, but
             # can be used by potential users of the orogen specification.
             def dynamic_output_port(name, type)
-                type = resolve_type_if_needed(type) if type
+                type = project.resolve_type(type) if type
                 dynamic_ports << DynamicOutputPort.new(self, name, type)
                 dynamic_ports.last
             end

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -619,7 +619,10 @@ module OroGen
                     accepted = [Numeric, Symbol, String, TrueClass, FalseClass]
                                .any? { |valid_klass| default_value.kind_of?(valid_klass) }
                     unless accepted
-                        raise ArgumentError, "default values for #{klass.name.downcase} can be specified only for simple types (numeric, string and boolean)"
+                        raise ArgumentError,
+                              "default values for #{klass.name} can be specified only for "\
+                              "simple types (numeric, string and boolean). Got #{default_value} "\
+                              "of type #{default_value.class}"
                     end
 
                     begin

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -1115,11 +1115,11 @@ module OroGen
             # corresponding OutputPort object.
             #
             # See also #input_port
-            def output_port(name, type, options = Hash.new)
+            def output_port(name, type, **options)
+                options = validate_options(options, class: OutputPort)
+
                 name = OroGen.verify_valid_identifier(name)
                 check_uniqueness(name)
-                options = Kernel.validate_options options,
-                                                  :class => OutputPort
 
                 @output_ports[name] = port = options[:class].new(self, name, type)
                 Spec.load_documentation(port, /output_port/)
@@ -1133,11 +1133,11 @@ module OroGen
             # corresponding InputPort object.
             #
             # See also #output_port
-            def input_port(name, type, options = Hash.new)
+            def input_port(name, type, **options)
+                options = Kernel.validate_options(options, class: InputPort)
+
                 name = OroGen.verify_valid_identifier(name)
                 check_uniqueness(name)
-                options = Kernel.validate_options options,
-                                                  :class => InputPort
 
                 @input_ports[name] = port = options[:class].new(self, name, type)
                 Spec.load_documentation(port, /input_port/)
@@ -1211,9 +1211,7 @@ module OroGen
 
             # Enumerates both the input and output ports
             def each_port(&block)
-                unless block_given?
-                    return enum_for(:each_port, &block)
-                end
+                return enum_for(:each_port) unless block_given?
 
                 each_input_port(&block)
                 each_output_port(&block)

--- a/test/gen/test_tasks.rb
+++ b/test/gen/test_tasks.rb
@@ -6,9 +6,58 @@ class TC_GenerationTasks < Minitest::Test
     attr_reader :task, :project
     def setup
         @project = OroGen::Gen::RTT_CPP::Project.new
+        @project.import_types_from "std"
         project.name "test"
         @task = project.task_context "Task"
         super
+    end
+
+    def test_it_validates_that_the_task_name_is_a_proper_cpp_identifier
+        assert_raises(ArgumentError) { project.task_context("bla bla") }
+        assert_raises(ArgumentError) { project.task_context("bla(bla") }
+        assert_raises(ArgumentError) { project.task_context("bla!bla") }
+        assert_raises(ArgumentError) { project.task_context("bla/bla") }
+        project.task_context("bla")
+    end
+
+    def test_it_validates_that_property_names_are_valid_cpp_identifiers
+        assert_raises(ArgumentError) { task.property("bla bla", "/double") }
+        assert_raises(ArgumentError) { task.property("bla(bla", "/double") }
+        assert_raises(ArgumentError) { task.property("bla!bla", "/double") }
+        assert_raises(ArgumentError) { task.property("bla/bla", "/double") }
+        task.property("bla", "/double")
+    end
+
+    def test_it_validates_that_attribute_names_are_valid_cpp_identifiers
+        assert_raises(ArgumentError) { task.attribute("bla bla", "/double") }
+        assert_raises(ArgumentError) { task.attribute("bla(bla", "/double") }
+        assert_raises(ArgumentError) { task.attribute("bla!bla", "/double") }
+        assert_raises(ArgumentError) { task.attribute("bla/bla", "/double") }
+        task.attribute("bla", "/double")
+    end
+
+    def test_it_validates_that_output_port_names_are_valid_cpp_identifiers
+        assert_raises(ArgumentError) { task.output_port("bla bla", "/double") }
+        assert_raises(ArgumentError) { task.output_port("bla(bla", "/double") }
+        assert_raises(ArgumentError) { task.output_port("bla!bla", "/double") }
+        assert_raises(ArgumentError) { task.output_port("bla/bla", "/double") }
+        task.output_port("bla", "/double")
+    end
+
+    def test_it_validates_that_input_port_names_are_valid_cpp_identifiers
+        assert_raises(ArgumentError) { task.input_port("bla bla", "/double") }
+        assert_raises(ArgumentError) { task.input_port("bla(bla", "/double") }
+        assert_raises(ArgumentError) { task.input_port("bla!bla", "/double") }
+        assert_raises(ArgumentError) { task.input_port("bla/bla", "/double") }
+        task.input_port("bla", "/double")
+    end
+
+    def test_it_validates_that_operation_names_are_valid_cpp_identifiers
+        assert_raises(ArgumentError) { task.operation("bla bla") }
+        assert_raises(ArgumentError) { task.operation("bla(bla") }
+        assert_raises(ArgumentError) { task.operation("bla!bla") }
+        assert_raises(ArgumentError) { task.operation("bla/bla") }
+        task.operation("bla")
     end
 
     # Orogen should refuse to create a task context which has the same name than
@@ -141,6 +190,7 @@ class TC_GenerationTasks < Minitest::Test
     def test_it_can_generate_tasks_with_a_default_activity
         task.default_activity :periodic, 10
         deployment = project.deployment "test"
+        project.enable_transports "corba"
         deployment.task "test", task
         create_wc("tasks/default_activity")
         compile_wc(project)

--- a/test/spec/test_task_context.rb
+++ b/test/spec/test_task_context.rb
@@ -72,13 +72,6 @@ describe OroGen::Spec::TaskContext do
             assert_raises(ArgumentError) { task.property("bla", "/double") }
         end
 
-        it "should validate property names" do
-            assert_raises(ArgumentError) { task.property("bla bla", "/double") }
-            assert_raises(ArgumentError) { task.property("bla(bla", "/double") }
-            assert_raises(ArgumentError) { task.property("bla!bla", "/double") }
-            assert_raises(ArgumentError) { task.property("bla/bla", "/double") }
-        end
-
         it "should register the property in #self_properties" do
             property = task.property("p", "/double")
             assert_equal [property], task.self_properties


### PR DESCRIPTION
The name constraints are there only to please C++. Dynamically created
interface objects can have any name.