### PR TITLE
Improve handling of -std= from pkg-config cflags

### DIFF
--- a/lib/orogen/templates/project.orogen
+++ b/lib/orogen/templates/project.orogen
@@ -23,4 +23,9 @@ using_typekit "<%= tk.name %>"
 
 <%= File.read(project.deffile) %>
 
+<% if project.cxx_standard %>
+# override the c++ standard with the final result at generation time
+cxx_standard = "<%= project.cxx_standard %>"
+<% end %>
+
 Spec::TaskContext.pop_default_extensions_state

--- a/lib/orogen/templates/tasks/CMakeLists.txt
+++ b/lib/orogen/templates/tasks/CMakeLists.txt
@@ -21,6 +21,10 @@ SET_TARGET_PROPERTIES(${<%= project.name.upcase %>_TASKLIB_NAME}
 SET_TARGET_PROPERTIES(${<%= project.name.upcase %>_TASKLIB_NAME}
     PROPERTIES INTERFACE_LINK_LIBRARIES "${<%= project.name.upcase %>_TASKLIB_INTERFACE_LIBRARIES}")
 
+<% if project.cxx_standard %>
+TARGET_COMPILE_FEATURES(${<%= project.name.upcase %>_TASKLIB_NAME} PUBLIC <%= project.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
+
 INSTALL(TARGETS ${<%= project.name.upcase %>_TASKLIB_NAME}
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib/orocos)

--- a/lib/orogen/templates/typekit/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/CMakeLists.txt
@@ -109,6 +109,9 @@ if(WITH_RPATH AND APPLE)
     INSTALL_NAME_DIR "@rpath")
     SET(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 endif()
+<% if typekit.cxx_standard %>
+target_compile_features(${libname} PUBLIC <%= typekit.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
 set(PKG_CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/<%= typekit.name %>-typekit-${OROCOS_TARGET}.pc)
 configure_file(<%= typekit.name %>-typekit.pc.in ${PKG_CONFIG_FILE} @ONLY)
 

--- a/lib/orogen/templates/typekit/corba/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/corba/CMakeLists.txt
@@ -55,6 +55,10 @@ endif()
 set_target_properties(${libname_corba} PROPERTIES LINK_INTERFACE_LIBRARIES ${OrocosCORBA_LIBRARIES})
 set_target_properties(${libname_corba} PROPERTIES INTERFACE_LINK_LIBRARIES ${OrocosCORBA_LIBRARIES})
 
+<% if typekit.cxx_standard %>
+target_compile_features(${libname_corba} PUBLIC <%= typekit.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
+
 SET(PKG_CONFIG_FILE_CORBA ${CMAKE_CURRENT_BINARY_DIR}/<%= typekit.name %>-transport-corba-${OROCOS_TARGET}.pc)
 CONFIGURE_FILE(<%= typekit.name %>-transport-corba.pc.in ${PKG_CONFIG_FILE_CORBA} @ONLY)
 

--- a/lib/orogen/templates/typekit/mqueue/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/mqueue/CMakeLists.txt
@@ -28,6 +28,10 @@ target_link_libraries(${libname_mqueue}
     ${OROCOS-RTT_MQUEUE_LIBRARIES}
     ${RTT_Typelib_LIBRARIES})
 
+<% if typekit.cxx_standard %>
+target_compile_features(${libname_mqueue} PUBLIC <%= typekit.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
+
 <%= Generation.cmake_pkgconfig_link('mqueue', '${libname_mqueue}', typekit_deps) %>
 
 SET(PKG_CONFIG_FILE_MQueue ${CMAKE_CURRENT_BINARY_DIR}/<%= typekit.name %>-transport-mqueue-${OROCOS_TARGET}.pc)

--- a/lib/orogen/templates/typekit/ros/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/ros/CMakeLists.txt
@@ -93,6 +93,9 @@ set_source_files_properties(<%= impl.join(" ") %>
 target_link_libraries(${libname_ros}
     <%= typekit.name %>-typekit-${OROCOS_TARGET}
     ${OrocosROS_LIBRARIES})
+<% if typekit.cxx_standard %>
+target_compile_features(${libname_ros} PUBLIC <%= typekit.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
 <%= Generation.cmake_pkgconfig_link('ros', '${libname_ros}', typekit_deps) %>
 
 SET(PKG_CONFIG_FILE_ROS ${CMAKE_CURRENT_BINARY_DIR}/<%= typekit.name %>-transport-ros-${OROCOS_TARGET}.pc)

--- a/lib/orogen/templates/typekit/typekit.pc
+++ b/lib/orogen/templates/typekit/typekit.pc
@@ -16,5 +16,5 @@ Version: <%= typekit.version %>
 Requires: <%= (typekit.internal_dependencies.map { |n, v| v ? "#{n} >= #{v}" : n.to_s } + typekit.linked_used_libraries.map(&:name)).join(", ") %>
 Description: <%= typekit.name %> types support for the Orocos type system
 Libs: -L${libdir} -l@libname@
-Cflags: -I${includedir} -I${includedir}/<%= typekit.name %>/types <%= typekit.loaded_files_dirs.map { |s| "-I#{s}" }.join(" ") %> @PKG_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/<%= typekit.name %>/types <%= typekit.loaded_files_dirs.map { |s| "-I#{s}" }.join(" ") %> @PKG_CFLAGS@ <%= typekit.cxx_standard ? "-std=#{typekit.cxx_standard}" : "" %>
 

--- a/lib/orogen/templates/typekit/typelib/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/typelib/CMakeLists.txt
@@ -29,6 +29,10 @@ target_link_libraries(${libname_typelib}
     <%= typekit.name %>-typekit-${OROCOS_TARGET}
     <% end %>)
 
+<% if typekit.cxx_standard %>
+target_compile_features(${libname_typelib} PUBLIC <%= typekit.cxx_standard.sub(/^(c|gnu)\+\+/, "cxx_std_") %>)
+<% end %>
+
 <%= Generation.cmake_pkgconfig_link('typelib', '${libname_typelib}', typekit_deps) %>
 
 # rospack support: if we're a ROS package, use rospack to return the location of our .tlb file.


### PR DESCRIPTION
Since compilers use only the last of multiple -std= arguments, tools that merge multiple sets of cflags must be smart to select a good standard(if any).

I will add tests once the general how and where has been settled.

@doudou this is one piece to solve a troubling issue where multiple packages specify multiple different -std flags because of their various requirements. There are many packages that want at least c++11 , but then there are the pcl users that want c++14, while ubuntu 18.04s compiler defaults to c++98, so just having c++14 where needed is not an option since elsewhere c++11 is needed. 

The other piece would be to make base/cmake/modules/Rock.cmake smarter, but there, one "just" needs to parse the -std out of the cflags, pass them to *compile_features and cmake figures out which standard to use. My version of that currently is [here](https://github.com/rock-core/base-cmake/commit/1e260881d7ea4e18ecf29af94151e3e75576585b)(or one of the commits of [this branch](https://github.com/pierrewillenbrockdfki/base-cmake/tree/wip-qt5), when i rebase again)