### PR TITLE
Fix tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ def minitest_set_options(test_task, name)
     test_task.options = "#{TESTOPTS} #{minitest_args} -- --simplecov-name=#{name}"
 end
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new("test:core") do |t|
     t.libs << "lib"
     minitest_set_options(t, "core")
     t.libs << "test"
@@ -65,6 +65,8 @@ Rake::TestTask.new(:test) do |t|
         fl.exclude { |p| %r{^test/gen}.match?(p) }
     end
 end
+
+task "test" => "test:core"
 
 Rake::TestTask.new("test:gen") do |t|
     t.libs << "lib"

--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -515,7 +515,8 @@ module OroGen
             # @return [(String,String)] the model as text, as well as a path to
             #   the model file (or nil if there is no such file)
             def project_model_text_from_name(name)
-                raise NotImplementedError, "textual representation of project #{name} not registered on #{self}"
+                raise NotImplementedError, "textual representation of project " \
+                                           "#{name} not registered on #{self}"
             end
 
             # Returns the textual representation of a typekit

--- a/lib/orogen/spec/project.rb
+++ b/lib/orogen/spec/project.rb
@@ -167,6 +167,12 @@ module OroGen
                     return
                 end
 
+                if name == self.name
+                    raise ArgumentError, "a task cannot have the same name as the project"
+                elsif name !~ /^(\w+::)*\w+$/
+                    raise ArgumentError, "task names need to be valid C++ identifiers, i.e. contain only alphanumeric characters and _ (got #{name})"
+                end
+
                 task = external_task_context(name, subclasses: subclasses, **options, &block)
                 task.extended_state_support
                 self_tasks[task.name] = task

--- a/manifest.xml
+++ b/manifest.xml
@@ -23,6 +23,9 @@
     <rosdep name="ruby" />
 
     <test_depend package="minitest" />
+    <test_depend package="minitest-junit" />
     <test_depend package="flexmock" />
+    <test_depend package="rubocop" />
+    <test_depend package="rubocop-rock" />
 </package>
 

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -18,4 +18,3 @@ module OroGen
         end
     end
 end
-


### PR DESCRIPTION
This makes `autoproj test orogen` pass, provided that the new rubocop cops are set to enabled or disabled somewhere, except for Layout/EmptyLinesAroundAttributeAccessor, which would need to be disabled or have a lot of lines added everywhere with some exclusions for `attr_predicate`, that is not recognized as AttributeAccessor.