### PR TITLE
fix: avoid creation of a non-virtual 'orocos' typekit in Loaders::RTT

### DIFF
--- a/lib/orogen/loaders/rtt.rb
+++ b/lib/orogen/loaders/rtt.rb
@@ -21,9 +21,8 @@ module OroGen
                 super
             end
 
-            def self.standard_projects
+            def self.standard_projects(loader: self.loader)
                 unless @standard_projects
-                    loader = self.loader
                     @standard_projects = STANDARD_PROJECT_SPECS.map do |name, dir|
                         loader.project_model_from_name(name)
                     end
@@ -31,9 +30,8 @@ module OroGen
                 @standard_projects
             end
 
-            def self.standard_typekits
+            def self.standard_typekits(loader: self.loader)
                 unless @standard_typekits
-                    loader = self.loader
                     @standard_typekits = STANDARD_TYPEKIT_SPECS.map do |name, _|
                         typekit = loader.typekit_model_from_name(name)
                         typekit.virtual = true
@@ -50,7 +48,8 @@ module OroGen
             end
 
             def self.setup_loader(loader)
-                standard_typekits.each do |tk|
+                standard_loader = self.loader
+                standard_typekits(loader: standard_loader).each do |tk|
                     loader.register_typekit_model(tk)
                     # One additional step for us: register the types in
                     # tk.typelist manually. This is needed as we use the
@@ -60,7 +59,7 @@ module OroGen
                         loader.typekits_by_type_name[typename] << tk
                     end
                 end
-                standard_projects.each do |proj|
+                standard_projects(loader: standard_loader).each do |proj|
                     loader.register_project_model(proj)
                 end
             end


### PR DESCRIPTION
The standard_projects and standard_typekits calls were separately creating a RTT.loader when called from setup_loader (the actual public entry point), which in turn would create more than one time the "virtual" orocos typekit model.

Make sure that setup_loader creates the loader only once.