### PR TITLE
chore: implement --control-fd in deployments to avoid using signals to quit the deployment process

### DIFF
--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -485,7 +485,7 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
         message_ostream << ",";
     <% end %>
     <% end %>
-        message_ostream << "}";
+        message_ostream << "}\n";
         std::string message = message_ostream.str();
         while (write_result < static_cast<int>(message.length())) {
             message.erase(0, write_result);


### PR DESCRIPTION
Generally speaking signals are fragile things...

But more specifically, I sat on this change for a while. It was made necessary for the integration of `rr` as a mode of execution in Syskit, which does not support signals very well.