### PR TITLE
feat: define Spec::OutputPort#init_policy

### DIFF
--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -135,6 +135,18 @@ module OroGen
             def triggered_once_per_update?
                 !!@triggered_once_per_update
             end
+
+            # Used to set the recommend_init flag directly
+            attr_writer :recommend_init
+
+            # Returns whether the port recommends using 'init: true' when connecting.
+            # This policy flag requests that the connection sends the last value
+            # written to it.
+            #
+            # Defaults to true if not explicitly set
+            def recommend_init
+                @recommend_init.nil? ? true : @recommend_init
+            end
         end
     end
 end

--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -137,9 +137,6 @@ module OroGen
                 !!@triggered_once_per_update
             end
 
-            # Sets and gets the init policy
-            attr_writer :init_policy
-
             # Calls keep_last_written_value(value) if value is a Boolean
             def init_policy(value = nil)
                 return @init_policy if value.nil?

--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -138,20 +138,21 @@ module OroGen
             end
 
             def init_policy?
-                @init_policy == true
+                @init_policy
             end
-
-            # Calls keep_last_written_value(value) if value is a Boolean
-            def init_policy(value = nil)
-                return @init_policy if value.nil?
-
-                unless [true, false].include?(value)
+             
+            # Calls keep_last_written_value(value)
+            def init_policy(*value)
+                return @init_policy if value.empty?
+                if value.size > 1
                     raise ArgumentError,
-                          "init_policy can only be called with " \
-                          "true or false. Got #{value.inspect}"
+                          "init_policy accepts at most one argument, " \
+                          "but got #{value.size}"
                 end
-                @init_policy = value
-                keep_last_written_value(value)
+
+                @init_policy = value.first
+                keep_last_written_value(value.first)
+                self
             end
         end
     end

--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -137,6 +137,10 @@ module OroGen
                 !!@triggered_once_per_update
             end
 
+            def init_policy?
+                @init_policy == true
+            end
+
             # Calls keep_last_written_value(value) if value is a Boolean
             def init_policy(value = nil)
                 return @init_policy if value.nil?

--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -12,6 +12,7 @@ module OroGen
                 @burst_period = 0
                 @port_triggers = Set.new
                 @triggered_on_update = nil
+                @init_policy = nil
             end
 
             attr_reader :burst_size
@@ -136,16 +137,19 @@ module OroGen
                 !!@triggered_once_per_update
             end
 
-            # Used to set the recommend_init flag directly
-            attr_writer :recommend_init
+            # Stores the current init policy, as set by recommend_init
+            attr_reader :init_policy
 
-            # Returns whether the port recommends using 'init: true' when connecting.
-            # This policy flag requests that the connection sends the last value
-            # written to it.
-            #
-            # Defaults to true if not explicitly set
-            def recommend_init
-                @recommend_init.nil? ? true : @recommend_init
+            # Calls keep_last_written_value(true) as default
+            def recommend_init(init: true)
+                unless [true, false].include?(init)
+                    raise ArgumentError,
+                          "recommend_init can only be called with true or false. " \
+                          "Got #{init.nil? ? 'nil' : init}"
+                end
+
+                @init_policy = init
+                keep_last_written_value(init)
             end
         end
     end

--- a/lib/orogen/spec/output_port.rb
+++ b/lib/orogen/spec/output_port.rb
@@ -137,19 +137,20 @@ module OroGen
                 !!@triggered_once_per_update
             end
 
-            # Stores the current init policy, as set by recommend_init
-            attr_reader :init_policy
+            # Sets and gets the init policy
+            attr_writer :init_policy
 
-            # Calls keep_last_written_value(true) as default
-            def recommend_init(init: true)
-                unless [true, false].include?(init)
+            # Calls keep_last_written_value(value) if value is a Boolean
+            def init_policy(value = nil)
+                return @init_policy if value.nil?
+
+                unless [true, false].include?(value)
                     raise ArgumentError,
-                          "recommend_init can only be called with true or false. " \
-                          "Got #{init.nil? ? 'nil' : init}"
+                          "init_policy can only be called with " \
+                          "true or false. Got #{value.inspect}"
                 end
-
-                @init_policy = init
-                keep_last_written_value(init)
+                @init_policy = value
+                keep_last_written_value(value)
             end
         end
     end

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -16,15 +16,15 @@ module OroGen
                 refute @port.input?
             end
 
-            it "initializes init_policy as nil" do
-                assert_nil @port.init_policy
+            it "defaults init_policy as not defined (false)" do
+                refute @port.init_policy?
             end
 
             it "resets init_policy when port is created again" do
                 @port.init_policy(true)
-                assert @port.init_policy
+                assert @port.init_policy?
                 @port = OutputPort.new(@task, "test", "/double")
-                assert_nil @port.init_policy
+                refute @port.init_policy?
             end
 
             it "defaults keep_last_written_value to :initial" do
@@ -44,13 +44,13 @@ module OroGen
             it "sets init_policy to true and expects to get current value when " \
                "calling init_policy" do
                 @port.init_policy(true)
-                assert @port.init_policy
+                assert @port.init_policy?
             end
 
             it "sets init_policy to false and expects to get current value when " \
                "calling init_policy" do
                 @port.init_policy(false)
-                refute @port.init_policy
+                refute @port.init_policy?
             end
 
             it "raises ArgumentError if init_policy is called " \

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -16,18 +16,41 @@ module OroGen
                 refute @port.input?
             end
 
-            it "defaults recommend_init to true" do
-                assert @port.recommend_init
+            it "initializes init_policy as nil" do
+                assert_nil @port.init_policy
             end
 
-            it "allows recommend_init to be explicitly set to false" do
-                @port.recommend_init = false
-                refute @port.recommend_init
-            end
-
-            it "sets recommend_init when recommends_init is called" do
+            it "resets init_policy when port is created again" do
                 @port.recommend_init
-                assert @port.recommend_init
+                assert @port.init_policy
+                @port = OutputPort.new(@task, "test", "/double")
+                assert_nil @port.init_policy
+            end
+
+            it "defaults keep_last_written_value to :initial" do
+                assert_equal @port.keep_last_written_value, :initial
+            end
+
+            it "calls keep_last_written_value(true) with recommend_init" do
+                @port.recommend_init
+                assert @port.keep_last_written_value
+            end
+
+            it "calls keep_last_written_value(false) with " \
+               "recommend_init(init: false)" do
+                @port.recommend_init(init: false)
+                refute @port.keep_last_written_value
+            end
+
+            it "raises ArgumentError if recommend_init is called " \
+               "with an invalid value (other than true or false)" do
+                begin
+                    @port.recommend_init(init: nil)
+                rescue ArgumentError => e
+                    assert_equal e.message,
+                                 "recommend_init can only be called with " \
+                                 "true or false. Got nil"
+                end
             end
         end
     end

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -54,14 +54,19 @@ module OroGen
             end
 
             it "raises ArgumentError if init_policy is called " \
-               "with an invalid value (other than true or false)" do
+               "with more than one argument" do
                 begin
-                    @port.init_policy(nil)
+                    @port.init_policy(nil, "bla")
                 rescue ArgumentError => e
                     assert_equal e.message,
-                                 "init_policy can only be called with " \
-                                 "true or false. Got nil"
+                                 "init_policy accepts at most one argument, " \
+                                 "but got 2"
                 end
+            end
+
+            it "allows method chaining when setting init_policy" do
+                assert_equal @port, @port.init_policy(true)
+                assert_equal @port, @port.init_policy(false).burst(1)
             end
         end
     end

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -21,7 +21,7 @@ module OroGen
             end
 
             it "resets init_policy when port is created again" do
-                @port.recommend_init
+                @port.init_policy(true)
                 assert @port.init_policy
                 @port = OutputPort.new(@task, "test", "/double")
                 assert_nil @port.init_policy
@@ -31,24 +31,35 @@ module OroGen
                 assert_equal @port.keep_last_written_value, :initial
             end
 
-            it "calls keep_last_written_value(true) with recommend_init" do
-                @port.recommend_init
+            it "calls keep_last_written_value(true) with init_policy(true)" do
+                @port.init_policy(true)
                 assert @port.keep_last_written_value
             end
 
-            it "calls keep_last_written_value(false) with " \
-               "recommend_init(init: false)" do
-                @port.recommend_init(init: false)
+            it "calls keep_last_written_value(false) with init_policy(false)" do
+                @port.init_policy(false)
                 refute @port.keep_last_written_value
             end
 
-            it "raises ArgumentError if recommend_init is called " \
+            it "sets init_policy to true and expects to get current value when " \
+               "calling init_policy" do
+                @port.init_policy(true)
+                assert @port.init_policy
+            end
+
+            it "sets init_policy to false and expects to get current value when " \
+               "calling init_policy" do
+                @port.init_policy(false)
+                refute @port.init_policy
+            end
+
+            it "raises ArgumentError if init_policy is called " \
                "with an invalid value (other than true or false)" do
                 begin
-                    @port.recommend_init(init: nil)
+                    @port.init_policy(nil)
                 rescue ArgumentError => e
                     assert_equal e.message,
-                                 "recommend_init can only be called with " \
+                                 "init_policy can only be called with " \
                                  "true or false. Got nil"
                 end
             end

--- a/test/spec/test_output_port.rb
+++ b/test/spec/test_output_port.rb
@@ -15,6 +15,20 @@ module OroGen
             it "returns false in input?" do
                 refute @port.input?
             end
+
+            it "defaults recommend_init to true" do
+                assert @port.recommend_init
+            end
+
+            it "allows recommend_init to be explicitly set to false" do
+                @port.recommend_init = false
+                refute @port.recommend_init
+            end
+
+            it "sets recommend_init when recommends_init is called" do
+                @port.recommend_init
+                assert @port.recommend_init
+            end
         end
     end
 end


### PR DESCRIPTION
The `recommend_init` flag allows syskit to add `init: true` bu default in port connections
The `init: true` policy requests that the connection sends the last value written to it.