### PR TITLE
Fix deprecated usage of `ERB.new`

### DIFF
--- a/lib/orogen/gen/templates.rb
+++ b/lib/orogen/gen/templates.rb
@@ -51,8 +51,8 @@ module OroGen
 
                     templates[path] =
                         begin
-                            ERB.new(File.read(template_file), nil, "<>",
-                                    path.join("_").downcase.gsub(%r{[\/\.-]}, "_"))
+                            ERB.new(File.read(template_file), trim_mode: "<>",
+                                    eoutvar: path.join("_").downcase.gsub(%r{[\/\.-]}, "_"))
                         rescue Errno::ENOENT
                             raise ArgumentError, "template #{File.join(*path)} "\
                                                  "does not exist"


### PR DESCRIPTION
Under Ubuntu 20.04 this fixes deprecation warnings:

```
/opt/workspace/tools/orogen/lib/orogen/gen/templates.rb:54: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/opt/workspace/tools/orogen/lib/orogen/gen/templates.rb:54: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/opt/workspace/tools/orogen/lib/orogen/gen/templates.rb:54: warning: Passing eoutvar with the 4th argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, eoutvar: ...) instead.
/opt/workspace/tools/orogen/lib/orogen/gen/templates.rb:54: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
```

For Ubuntu 24.04 without this change, orogen recently ceased to work.
