### PR TITLE
Make `timeout` a positional argument of `triggered`

### DIFF
--- a/lib/orogen/spec/deployment.rb
+++ b/lib/orogen/spec/deployment.rb
@@ -393,7 +393,7 @@ module OroGen
             # @param [Float,nil] timeout timeout in seconds or nil for no timeout.
             #   If this timeout is given, the task will be called after this many
             #   seconds have passed without an explicit trigger.
-            def triggered(timeout: nil)
+            def triggered(timeout=nil)
                 activity_type "Triggered", "RTT::Activity", "rtt/Activity.hpp"
                 activity_setup do
                     activity_new = <<~EOD

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -1338,7 +1338,7 @@ module OroGen
             # @param [Float,nil] timeout in seconds. If non-nil, the task will be
             #   called after this many seconds have passed without being triggered
             def port_driven(*names, timeout: nil)
-                default_activity "triggered", timeout: timeout
+                default_activity "triggered", timeout
                 names = names.map(&:to_s)
                 relevant_ports =
                     if names.empty? then all_input_ports


### PR DESCRIPTION
This allows calling it via `send` in `@explicit_activity` without deprecation warnings in ruby 2.7, and failures in ruby 3.2

@pierrewillenbrockdfki FYI