### PR TITLE
chore: be compatible with a RTT built without its built-in typekit

### DIFF
--- a/lib/orogen/loaders/rtt.rb
+++ b/lib/orogen/loaders/rtt.rb
@@ -3,9 +3,25 @@
 module OroGen
     module Loaders
         class RTT < PkgConfig
+            def self.has_builtin_typekit?
+                ENV["ROCK_RTT_BUILTIN_TYPEKIT"] != "0"
+            end
+
             DIR = File.join(__dir__, "rtt")
-            STANDARD_PROJECT_SPECS = { "RTT" => DIR, "OCL" => DIR }
-            STANDARD_TYPEKIT_SPECS = { "orocos" => DIR }
+            STANDARD_PROJECT_SPECS =
+                if has_builtin_typekit?
+                    { "RTT" => DIR, "OCL" => DIR }
+                else
+                    { "RTT" => DIR }
+                end
+
+            STANDARD_TYPEKIT_SPECS =
+                if has_builtin_typekit?
+                    { "orocos" => DIR }
+                else
+                    {}
+                end
+
             def self.loader
                 loader = Files.new
                 STANDARD_PROJECT_SPECS.each do |name, dir|

--- a/lib/orogen/templates/config/Deployment.cmake
+++ b/lib/orogen/templates/config/Deployment.cmake
@@ -40,11 +40,15 @@ target_link_libraries(<%= deployer.name %> ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${
 <% end %>
 
 list(APPEND CMAKE_PREFIX_PATH ${OrocosRTT_PREFIX})
+
+<% if OroGen::Loaders::RTT.has_builtin_typekit? %>
 find_package(RTTPlugin COMPONENTS rtt-typekit <%= deployer.rtt_transports.map { |transport_name| "rtt-transport-#{transport_name}" }.join(" ") %>)
 target_link_libraries(<%= deployer.name %> ${RTT_PLUGIN_rtt-typekit_LIBRARY})
 <% deployer.rtt_transports.each do |transport_name| %>
 target_link_libraries(<%= deployer.name %> ${RTT_PLUGIN_rtt-transport-<%= transport_name %>_LIBRARY})
 <% end %>
+<% end %>
+
 <% if !project.self_tasks.empty? %>
 target_link_libraries(<%= deployer.name %> <%= project.name %>-tasks-${OROCOS_TARGET})
 <% end %>

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -11,12 +11,14 @@
 #endif // OROGEN_SERVICE_DISCOVERY_ACTIVATED
 <% end %>
 
+<% if OroGen::Loaders::RTT.has_builtin_typekit? %>
 #include <rtt/typekit/RealTimeTypekit.hpp>
 <% if deployer.transports.include?('corba') %>
 #include <rtt/transports/corba/TransportPlugin.hpp>
 <% end %>
 <% if deployer.transports.include?('mqueue') %>
 #include <rtt/transports/mqueue/TransportPlugin.hpp>
+<% end %>
 <% end %>
 
 <% if project.typekit || !project.used_typekits.empty? %>
@@ -268,12 +270,14 @@ int ORO_main(int argc, char* argv[])
        <% end %>
    <% end %>
 
+   <% if OroGen::Loaders::RTT.has_builtin_typekit? %>
    RTT::types::TypekitRepository::Import( new RTT::types::RealTimeTypekitPlugin );
    <% if deployer.transports.include?('corba') %>
    RTT::types::TypekitRepository::Import( new RTT::corba::CorbaLibPlugin );
    <% end %>
    <% if deployer.transports.include?('mqueue') %>
    RTT::types::TypekitRepository::Import( new RTT::mqueue::MQLibPlugin );
+   <% end %>
    <% end %>
 
 <% if deployer.corba_enabled? %>


### PR DESCRIPTION
To allow building workspaces with RTT's PLUGINS_ENABLE_TYPEKIT set to OFF

Required by https://github.com/rock-core/rtt/pull/21

This is still not system-tested, so it might actually not work at all.