### PR TITLE
Pass kwargs

### DIFF
--- a/lib/orogen/loaders/project.rb
+++ b/lib/orogen/loaders/project.rb
@@ -8,8 +8,14 @@ module OroGen
                 @spec = spec
             end
 
-            def method_missing(m, *args, &block)
-                @spec.send(m, *args, &block)
+            def method_missing(m, *args, **kw, &block)
+                # in ruby2.6, an empty kw hash will be passed as a positional
+                # empty hash to a function that does not take keyword arguments
+                if kw.empty?
+                    @spec.send(m, *args, &block)
+                else
+                    @spec.send(m, *args, **kw, &block)
+                end
             end
 
             def __normalize_typename(type)
@@ -122,6 +128,8 @@ module OroGen
             def method_missing(m, *args, **kw, &block)
                 return unless @spec.respond_to?(m)
 
+                # in ruby2.6, an empty kw hash will be passed as a positional
+                # empty hash to a function that does not take keyword arguments
                 if kw.empty?
                     @spec.send(m, *args, &block)
                 else

--- a/lib/orogen/spec/deployment.rb
+++ b/lib/orogen/spec/deployment.rb
@@ -218,7 +218,16 @@ module OroGen
 
                 @explicit_activity =
                     if task_model.default_activity
-                        send(*task_model.default_activity)
+                        # in ruby2.6, an empty kw hash will be passed as a positional
+                        # empty hash to a function that does not take keyword arguments
+                        if task_model.default_activity[2].empty?
+                            send(task_model.default_activity[0],
+                                *task_model.default_activity[1])
+                        else
+                            send(task_model.default_activity[0],
+                                *task_model.default_activity[1],
+                                **task_model.default_activity[2])
+                        end
                         task_model.required_activity?
                     end
 

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -20,11 +20,17 @@ module OroGen
                 @name = name
             end
 
-            def supercall(default, m, *args, &block)
+            def supercall(default, m, *args, **kw, &block)
                 if !task.superclass
                     default
                 elsif name && @super_ext || (@super_ext = task.superclass.find_extension(name))
-                    @super_ext.send(m, *args, &block)
+                    # in ruby2.6, an empty kw hash will be passed as a positional
+                    # empty hash to a function that does not take keyword arguments
+                    if kw.empty?
+                        @super_ext.send(m, *args, &block)
+                    else
+                        @super_ext.send(m, *args, **kw, &block)
+                    end
                 else
                     default
                 end

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -313,18 +313,30 @@ module OroGen
             ##
             # :method: required_activity
             # :call-seq:
-            #   required_activity 'activity_type', *args
+            #   required_activity 'activity_type', *args, **kw
             #
             # The kind of activity that must be used for this task context. This
             # is the name of the corresponding method on the deployment objects.
             # See ACTIVITY_TYPES for the list of known activity types.
             #
             # See also #default_activity
-            dsl_attribute :required_activity do |type, *args|
+            dsl_attribute :required_activity do |type, *args, **kw|
                 if respond_to?(type.to_sym)
-                    send(type.to_sym, *args)
+                    # in ruby2.6, an empty kw hash will be passed as a positional
+                    # empty hash to a function that does not take keyword arguments
+                    if kw.empty?
+                        send(type.to_sym, *args)
+                    else
+                        send(type.to_sym, *args, **kw)
+                    end
                 else
-                    default_activity type, *args
+                    # in ruby2.6, an empty kw hash will be passed as a positional
+                    # empty hash to a function that does not take keyword arguments
+                    if kw.empty?
+                        default_activity type, *args
+                    else
+                        default_activity type, *args, **kw
+                    end
                 end
                 self.required_activity = true
             end
@@ -332,7 +344,7 @@ module OroGen
             ##
             # :method: default_activity
             # :call-seq:
-            #   default_activity 'activity_type', *args
+            #   default_activity 'activity_type', *args, **kw
             #
             # The kind of activity that should be used by default. This is the
             # name of the corresponding method on the deployment objects
@@ -344,7 +356,7 @@ module OroGen
             # with this task context.
             #
             # See also #required_activity
-            dsl_attribute :default_activity do |type, *args|
+            dsl_attribute :default_activity do |type, *args, **kw|
                 if required_activity? && @default_activity
                     raise ArgumentError,
                           "the #{default_activity[0]} activity is required, you cannot change it"
@@ -355,7 +367,7 @@ module OroGen
                     raise ArgumentError, "#{type} is not a valid activity type"
                 end
 
-                [type, *args]
+                [type, args, kw]
             end
 
             # Declares that this task should be deployed using a default


### PR DESCRIPTION
This allows passing keyword arguments through some select methods where that is either required or as future-proofing. This is an alternative to https://github.com/rock-core/tools-orogen/pull/26 . 

This changes how default_activity is stored internally (from [functionsymbol, args...] to [functionsymbol, [args...], {kwargs...}])

This seems to work fine on ubuntu 20.04 and 22.04 and 24.04.