### PR TITLE
Remove non-existing include paths.

### DIFF
--- a/lib/orogen/templates/tasks/tasks.pc
+++ b/lib/orogen/templates/tasks/tasks.pc
@@ -29,8 +29,5 @@ Libs: <%= libs.to_a.sort.join(" ") %> -L${libdir} -l<%= project.name %>-tasks-<%
   cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
   cflags |= project.used_typekits.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
 %>
-<% if project.extended_state_support? %>
-<%   cflags << "-I${includedir}/#{project.name}/types" %>
-<% end %>
 Cflags: -I${includedir} <%= cflags.to_a.join(" ") %>
 

--- a/lib/orogen/templates/typekit/typekit.pc
+++ b/lib/orogen/templates/typekit/typekit.pc
@@ -16,5 +16,5 @@ Version: <%= typekit.version %>
 Requires: <%= (typekit.internal_dependencies.map { |n, v| v ? "#{n} >= #{v}" : n.to_s } + typekit.linked_used_libraries.map(&:name)).join(", ") %>
 Description: <%= typekit.name %> types support for the Orocos type system
 Libs: -L${libdir} -l@libname@
-Cflags: -I${includedir} -I${includedir}/<%= typekit.name %>/types <%= typekit.loaded_files_dirs.map { |s| "-I#{s}" }.join(" ") %> @PKG_CFLAGS@ <%= typekit.cxx_standard ? "-std=#{typekit.cxx_standard}" : "" %>
+Cflags: -I${includedir} <%= typekit.loaded_files_dirs.map { |s| "-I#{s}" }.join(" ") %> @PKG_CFLAGS@ <%= typekit.cxx_standard ? "-std=#{typekit.cxx_standard}" : "" %>
 


### PR DESCRIPTION
As fas as I can tell, include paths `orocos/<package>/types` never exist, so remove them from .pc files.

@pierrewillenbrockdfki @planthaber